### PR TITLE
Refactor connection handling into dedicated service

### DIFF
--- a/LeWM-Angular/src/app/modes/file.mode.spec.ts
+++ b/LeWM-Angular/src/app/modes/file.mode.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { FileMode, GraphData } from './file.mode';
 import { GraphStateService } from '../services/graph-state.service';
+import { ConnectionStateService } from '../services/connection-state.service';
 import { PinStateService } from '../services/pin-state.service';
 import { FileService } from '../services/file.service';
 import { GraphEdge } from '../models/graph-edge.model';
@@ -339,7 +340,7 @@ describe('FileMode', () => {
   describe('Real Integration Test', () => {
     it('should verify import/export round-trip preserves all connection metadata', () => {
       // This test uses real services to ensure no properties are lost
-      const realGraphState = new GraphStateService();
+      const realGraphState = new GraphStateService(new ConnectionStateService());
       const realPinState = new PinStateService();
       const realFileMode = new FileMode(realGraphState, realPinState, mockFileService);
 

--- a/LeWM-Angular/src/app/services/connection-state.service.spec.ts
+++ b/LeWM-Angular/src/app/services/connection-state.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { ConnectionStateService } from './connection-state.service';
+import { GraphEdge } from '../models/graph-edge.model';
+
+describe('ConnectionStateService', () => {
+  let service: ConnectionStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConnectionStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should generate a unique id when adding an edge with duplicate id', () => {
+    const initialCount = service.getEdges().length;
+    const newEdge: GraphEdge = { id: 'conn_1', from: 'power.+9V', to: 'mic1.OUT' };
+    service.addEdge(newEdge);
+    const edges = service.getEdges();
+    expect(edges.length).toBe(initialCount + 1);
+    const added = edges.find(e => e.from === newEdge.from && e.to === newEdge.to);
+    expect(added).toBeDefined();
+    expect(added!.id).not.toBe('conn_1');
+    const ids = edges.map(e => e.id!);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('should generate unique ids when adding multiple edges without ids', () => {
+    const initialCount = service.getEdges().length;
+    const countToAdd = 3;
+    for (let i = 0; i < countToAdd; i++) {
+      service.addEdge({ from: `nodeA.pin${i}`, to: `nodeB.pin${i}` });
+    }
+    const edges = service.getEdges();
+    expect(edges.length).toBe(initialCount + countToAdd);
+    const newEdges = edges.slice(-countToAdd);
+    const ids = newEdges.map(e => e.id!);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(countToAdd);
+  });
+
+  it('should regenerate a unique id when updating an edge to a duplicate id', () => {
+    service.addEdge({ id: 'e1', from: 'n1.p1', to: 'n2.p2' });
+    service.addEdge({ id: 'e2', from: 'n3.p3', to: 'n4.p4' });
+    service.updateEdge('e1', { id: 'e2', from: 'n1.p1', to: 'n2.p2' });
+    const after = service.getEdges();
+    const updated = after.find(e => e.from === 'n1.p1' && e.to === 'n2.p2');
+    expect(updated).toBeDefined();
+    expect(updated!.id).not.toBe('e2');
+    expect(updated!.id).not.toBe('e1');
+    const allIds = after.map(e => e.id!);
+    expect(new Set(allIds).size).toBe(allIds.length);
+  });
+});

--- a/LeWM-Angular/src/app/services/connection-state.service.ts
+++ b/LeWM-Angular/src/app/services/connection-state.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { GraphEdge } from '../models/graph-edge.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConnectionStateService {
+  private readonly defaultEdges: GraphEdge[] = [
+    { id: 'conn_1', from: 'power.+9V', to: 'reg.IN' },
+    { id: 'conn_2', from: 'power.GND', to: 'reg.GND' },
+    { id: 'conn_3', from: 'reg.OUT', to: 'amp1.VCC' },
+    { id: 'conn_4', from: 'mic1.OUT', to: 'r1.A' },
+    { id: 'conn_5', from: 'r1.B', to: 'amp1.+IN' },
+  ];
+
+  private readonly _edges = new BehaviorSubject<GraphEdge[]>(this.defaultEdges);
+
+  readonly edges$ = this._edges.asObservable();
+
+  getEdges(): GraphEdge[] {
+    return this._edges.getValue();
+  }
+
+  setEdges(edges: GraphEdge[]): void {
+    this._edges.next(edges);
+  }
+
+  addEdge(edge: GraphEdge): void {
+    const currentEdges = this._edges.getValue();
+    let newId = edge.id || `conn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const exists = (id: string) => currentEdges.some(e => e.id === id);
+    if (exists(newId)) {
+      do {
+        newId = `conn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      } while (exists(newId));
+    }
+    const newEdge = { ...edge, id: newId };
+    this._edges.next([...currentEdges, newEdge]);
+  }
+
+  removeEdge(edgeId: string): void {
+    const currentEdges = this._edges.getValue();
+    this._edges.next(currentEdges.filter(edge => edge.id !== edgeId));
+  }
+
+  updateEdge(edgeId: string, updatedEdge: GraphEdge): void {
+    const currentEdges = this._edges.getValue();
+    const edgeIndex = currentEdges.findIndex(e => e.id === edgeId);
+    if (edgeIndex === -1) {
+      console.warn(`Edge with id ${edgeId} not found`);
+      return;
+    }
+    let newId: string = updatedEdge.id ?? edgeId;
+    if (newId !== edgeId) {
+      const existsOther = (id: string) => currentEdges.some((e, idx) => idx !== edgeIndex && e.id === id);
+      if (existsOther(newId)) {
+        do {
+          newId = `conn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        } while (existsOther(newId));
+      }
+    } else {
+      newId = edgeId;
+    }
+    const newEdge = { ...updatedEdge, id: newId };
+    const updatedEdges = [...currentEdges];
+    updatedEdges[edgeIndex] = newEdge;
+    this._edges.next(updatedEdges);
+  }
+
+  notifyEdgeStateChange(): void {
+    const currentEdges = this._edges.getValue();
+    this._edges.next([...currentEdges]);
+  }
+
+  resetToDefaults(): void {
+    this._edges.next(this.defaultEdges);
+  }
+}


### PR DESCRIPTION
## Summary
- add `ConnectionStateService` to manage edges
- delegate edge logic from `GraphStateService` to the new service
- adjust tests and specs for the new dependency

## Testing
- `npm run lint --silent`
- `npm run build --silent`
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6868ad978ea8832a8e8ce56fb59d2c69