### PR TITLE
Add graph.node feature flag

### DIFF
--- a/LeWM-Angular/docs/feature-flags.md
+++ b/LeWM-Angular/docs/feature-flags.md
@@ -91,6 +91,12 @@ src/assets/features/
       "name": "advanced-features",
       "enabled": false,
       "dependencies": ["basic-graph-editing"]
+    },
+    {
+      "id": "graph-node",
+      "name": "graph.node",
+      "enabled": true,
+      "dependencies": ["basic-graph-editing"]
     }
   ]
 }

--- a/LeWM-Angular/src/app/app.component.html
+++ b/LeWM-Angular/src/app/app.component.html
@@ -3,6 +3,7 @@
   <header class="header" [style.height.px]="headerHeight">
     <h1>LeWM Graph Editor</h1>
     <p>Angular-based interactive graph visualization tool</p>
+    <app-feature-flag-toggle></app-feature-flag-toggle>
   </header>
   
   <!-- Horizontal resize handle for header -->

--- a/LeWM-Angular/src/app/app.component.ts
+++ b/LeWM-Angular/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { GraphEditorComponent } from './components/graph-editor/graph-editor.component';
 import { HandleComponent } from './components/handle/handle';
+import { FeatureFlagToggleComponent } from './components/feature-flag-toggle/feature-flag-toggle.component';
 
 @Component({
   selector: 'app-root',
@@ -16,7 +17,8 @@ import { HandleComponent } from './components/handle/handle';
     CommonModule,
     RouterModule,
     GraphEditorComponent,
-    HandleComponent
+    HandleComponent,
+    FeatureFlagToggleComponent
   ],
   styleUrl: './app.component.scss'
 })

--- a/LeWM-Angular/src/app/components/feature-flag-toggle/feature-flag-toggle.component.ts
+++ b/LeWM-Angular/src/app/components/feature-flag-toggle/feature-flag-toggle.component.ts
@@ -36,6 +36,5 @@ export class FeatureFlagToggleComponent implements OnInit {
 
   toggle(feature: FeatureGraphNode, state: boolean): void {
     this.featureService.setFeatureEnabled(feature.name, state);
-    feature.enabled = state;
   }
 }

--- a/LeWM-Angular/src/app/components/feature-flag-toggle/feature-flag-toggle.component.ts
+++ b/LeWM-Angular/src/app/components/feature-flag-toggle/feature-flag-toggle.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { FeatureGraphService } from '../../services/feature-graph.service';
+import { FeatureGraphNode } from '../../interfaces/feature-graph.interface';
+
+@Component({
+  selector: 'app-feature-flag-toggle',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="feature-toggle" *ngIf="features.length">
+      <div *ngFor="let feature of features" class="feature-row">
+        <label>
+          <input type="checkbox" [checked]="feature.enabled"
+                 (change)="toggle(feature, $event.target.checked)" />
+          {{ feature.name }}
+        </label>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .feature-toggle { padding: 0.5rem; }
+    .feature-row { margin-bottom: 0.25rem; }
+  `]
+})
+export class FeatureFlagToggleComponent implements OnInit {
+  features: FeatureGraphNode[] = [];
+  private featureService = inject(FeatureGraphService);
+
+  ngOnInit(): void {
+    this.featureService.featuresLoaded.subscribe(() => {
+      this.features = this.featureService.getAllFeatures();
+    });
+  }
+
+  toggle(feature: FeatureGraphNode, state: boolean): void {
+    this.featureService.setFeatureEnabled(feature.name, state);
+    feature.enabled = state;
+  }
+}

--- a/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.html
+++ b/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.html
@@ -1,7 +1,7 @@
 <div class="graph-editor">
   <div class="toolbar" [style.width.px]="toolbarWidth">
     <h3>Node Library</h3>
-    <div class="node-buttons">
+    <div class="node-buttons" *ngIf="featureService.isFeatureEnabled('graph.node')">
       <button *ngFor="let node of availableNodes" 
               (click)="addNode(node.type)"
               (keydown.enter)="addNode(node.type)"

--- a/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.ts
+++ b/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.ts
@@ -8,6 +8,7 @@ import { ModeManagerService } from '../../services/mode-manager.service';
 import { PinStateService } from '../../services/pin-state.service';
 import { PinSyncService } from '../../services/pin-sync.service';
 import { FileService } from '../../services/file.service';
+import { FeatureGraphService } from '../../services/feature-graph.service';
 import { GraphMode } from '../../interfaces/graph-mode.interface';
 import { Pin } from '../../interfaces/pin.interface';
 import { NormalMode } from '../../modes/normal.mode';
@@ -151,6 +152,7 @@ export class GraphEditorComponent implements OnInit, OnDestroy, AfterViewInit {
   private pinState = inject(PinStateService);
   private pinSync = inject(PinSyncService);
   private fileService = inject(FileService);
+  private featureService = inject(FeatureGraphService);
   private cdr = inject(ChangeDetectorRef);
 
   constructor() {
@@ -351,6 +353,10 @@ export class GraphEditorComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   addNode(type: string): void {
+    if (!this.featureService.isFeatureEnabled('graph.node')) {
+      console.warn('graph.node feature is disabled');
+      return;
+    }
     const template = this.availableNodes.find(c => c.type === type);
     if (!template) return;
 

--- a/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.ts
+++ b/LeWM-Angular/src/app/components/graph-editor/graph-editor.component.ts
@@ -152,7 +152,7 @@ export class GraphEditorComponent implements OnInit, OnDestroy, AfterViewInit {
   private pinState = inject(PinStateService);
   private pinSync = inject(PinSyncService);
   private fileService = inject(FileService);
-  private featureService = inject(FeatureGraphService);
+  public featureService = inject(FeatureGraphService);
   private cdr = inject(ChangeDetectorRef);
 
   constructor() {

--- a/LeWM-Angular/src/app/services/feature-graph.service.ts
+++ b/LeWM-Angular/src/app/services/feature-graph.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject } from 'rxjs';
-import { FeatureGraph } from '../interfaces/feature-graph.interface';
+import { FeatureGraph, FeatureGraphNode } from '../interfaces/feature-graph.interface';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -60,6 +60,24 @@ export class FeatureGraphService {
     return this.featureGraph.features
       .filter(feature => this.isFeatureEnabled(feature.name))
       .map(feature => feature.name);
+  }
+
+  /**
+   * Returns all features with their current state
+   */
+  getAllFeatures(): FeatureGraphNode[] {
+    return this.featureGraph ? [...this.featureGraph.features] : [];
+  }
+
+  /**
+   * Enables or disables a feature at runtime
+   */
+  setFeatureEnabled(featureName: string, enabled: boolean): void {
+    const feature = this.featureGraph?.features.find(f => f.name === featureName);
+    if (feature) {
+      feature.enabled = enabled;
+      this.featuresLoaded$.next(true);
+    }
   }
 
   /**

--- a/LeWM-Angular/src/assets/features/public/dev.graph.json
+++ b/LeWM-Angular/src/assets/features/public/dev.graph.json
@@ -7,8 +7,14 @@
     },
     {
       "id": "advanced-features",
-      "name": "advanced-features", 
+      "name": "advanced-features",
       "enabled": false,
+      "dependencies": ["basic-graph-editing"]
+    },
+    {
+      "id": "graph-node",
+      "name": "graph.node",
+      "enabled": true,
       "dependencies": ["basic-graph-editing"]
     }
   ]

--- a/LeWM-Angular/src/assets/features/public/prod.graph.json
+++ b/LeWM-Angular/src/assets/features/public/prod.graph.json
@@ -1,3 +1,9 @@
 {
-  "features": []
+  "features": [
+    {
+      "id": "graph-node",
+      "name": "graph.node",
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- introduce `graph.node` feature entry in feature graphs and docs
- show node tools only when `graph.node` enabled
- allow runtime toggling of features
- add a simple feature-flag toggle component

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6869b8047564832aa66d4b1f9db4e23f